### PR TITLE
Fixes #4: Implement input reports validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Options:
 ## Custom CSS
 Pages look can be customize by writing custom CSS at `<outputHtmlDir>/static/user-styles.css`.
 
-## Input JSON structure
+## Input reports structure
 The tool expects input JSON reports to be valid against the [report-schema.json](./src/report-schema.json) JSON Schema.
 
 E.g.:
@@ -52,4 +52,9 @@ E.g.:
     ...
   ]
 }
+```
+
+Invalid reports will produce an error log and will be skipped. E.g.:
+```
+Error: Invalid report "/there/my-parser.json": should have required property 'language' (.parser)
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -323,7 +323,6 @@
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
       "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1311,14 +1310,12 @@
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
-      "dev": true
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2014,8 +2011,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2836,8 +2832,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "react-is": {
       "version": "16.13.1",
@@ -3401,7 +3396,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "MuleSoft",
   "license": "ISC",
   "dependencies": {
+    "ajv": "^6.12.2",
     "commander": "^5.1.0",
     "fs-extra": "^9.0.0",
     "mustache": "^3.0.1"

--- a/test/fixtures/json/invalid-report.json
+++ b/test/fixtures/json/invalid-report.json
@@ -1,0 +1,15 @@
+{
+  "parser": {
+    "name": "banana-parser",
+    "language": 123123123123,
+    "url": "https://github.com/raml-org/webapi-parser",
+    "version": "^0.5.0"
+  },
+  "results": [
+    {
+      "file": "/tests/raml-1.0/Something/version/invalid-version-structure.raml",
+      "success": false,
+      "error": "Error: Unexpected key 'hello'"
+    }
+  ]
+}

--- a/test/integration/index.test.js
+++ b/test/integration/index.test.js
@@ -25,6 +25,12 @@ describe('index.generateReports()', function () {
       'webapi-parser_js_features_stats.html'
     ])
   })
+  it('should not generate html pages for invalid reports', function () {
+    const files = fs.readdirSync(htmlDir).filter(x => x.endsWith('.html'))
+    files.sort()
+    expect(files).to.not.include('banana-parser_js_detailed_report.html')
+    expect(files).to.not.include('banana-parser_js_features_stats.html')
+  })
   it('should copy static files', function () {
     const staticDir = path.join(htmlDir, 'static')
     const files = fs.readdirSync(staticDir)


### PR DESCRIPTION
Fixes #4

Input reports which are not valid are now skipped and ignored. They only produce an error log (see updated README).

I've already added JSON Schema used for validation by this commit https://github.com/jstoiko/tck-reporter/commit/b9f82e85c504cda752b0ae1a363d93b08d7918f4 to `master` and described it in README.

After the PR is merged:
- [ ] Tag on github
- [ ] Use new version in raml-tck
- [ ] Use new version in asyncapi/tck